### PR TITLE
Resolve clash between eslint and prittier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
     serviceworker: true,
   },
   rules: {
-    quotes: ['error', 'single'],
+    quotes: ['error', 'single', { avoidEscape: true }],
     'no-multiple-empty-lines': 'error',
     'no-console': env(1, 0),
     'no-debugger': env(1, 0),


### PR DESCRIPTION
When a string have to use single quote inside, like: ` "what's your name?"` there is clash between the prettier and the eslint. The Eslint rule does not like the double quotes and so on save the double quotes are replaced with single and the internal one is escaped (`'waht\'s your name?`). At this point the prettier starts complaining because the singleQuote rule tries to optimize the string and it decide to switch it back to  ` "what's your name?"`, which is the [optimal variant for prittier](https://prettier.io/docs/en/rationale.html#strings). And so on and so on. By enabling `avoidEscape` for  eslint both will work in similar way.


### Describe the background of your pull request

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated

By submitting this pull request I confirm that:
- I've read the contributing document https://github.com/cherrytwist/.github/blob/master/CONTRIBUTING.md.
- I've read and understand the Code of Conduct https://github.com/cherrytwist/.github/blob/master/CODE_OF_CONDUCT.md.
- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/cherrytwist/Coordination/blob/master/LICENSE.
- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
 
